### PR TITLE
Fix issue #22: Text area for 'prompt' keeps getting overwritten by subsequent characters

### DIFF
--- a/components/ui/prompt-block.tsx
+++ b/components/ui/prompt-block.tsx
@@ -32,18 +32,13 @@ export function PromptBlock({ id, content, onChange, onDelete }: PromptBlockProp
     setLocalContent(content);
   }, [content]);
   
-  // Focus the textarea when the component mounts with empty content
+  // Focus the textarea when the component mounts
   useEffect(() => {
     if (textareaRef.current) {
-      // Always focus the textarea
+      // Just focus the textarea on mount
       textareaRef.current.focus();
-      
-      // If there's content (like from a snippet), select it all
-      if (content) {
-        textareaRef.current.select();
-      }
     }
-  }, [content]);
+  }, []); // Only run on mount
   
   const handleChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
     const newContent = e.target.value;


### PR DESCRIPTION
This PR fixes issue #22 by modifying the useEffect hook in the PromptBlock component to only run once when the component mounts, instead of every time the content changes. This prevents the text area from being overwritten when typing.